### PR TITLE
Update htmlbuilder version and usage syntax

### DIFF
--- a/naas_drivers/input/emailbuilder.py
+++ b/naas_drivers/input/emailbuilder.py
@@ -165,7 +165,7 @@ class EmailBuilder(InDriver):
     def address(self, title, content):
         self.deprecatedPrint()
         return tags.Address([
-                attributes.InlineStyle(
+                attributes.Style(
                     font_size="16px",
                     font_style="normal",
                     font_weight="400",
@@ -180,7 +180,7 @@ class EmailBuilder(InDriver):
         self.deprecatedPrint()
         return tags.A([
                 attributes.Href(link),
-                attributes.InlineStyle(color=color, text_decoration="underline"),
+                attributes.Style(color=color, text_decoration="underline"),
             ],
             title,
         )
@@ -195,11 +195,11 @@ class EmailBuilder(InDriver):
     ):
         self.deprecatedPrint()
         return tags.Center([]
-            tags.Div([attributes.InlineStyle(margin="48px 0")],
+            tags.Div([attributes.Style(margin="48px 0")],
                 tags.A([
                     attributes.Class("button"),
                     attributes.Href(link),
-                    attributes.InlineStyle(
+                    attributes.Style(
                         background_color=background_color,
                         color=color,
                         border_radius="4px",
@@ -225,7 +225,7 @@ class EmailBuilder(InDriver):
     def info(self, *elems):
         self.deprecatedPrint()
         return tags.Div([
-                attributes.InlineStyle(
+                attributes.Style(
                     background_color="ghostwhite",
                     border_radius="4px",
                     padding="24px 48px",
@@ -288,7 +288,7 @@ class EmailBuilder(InDriver):
                 res.append(tags.Td([], row if isinstance(row, str) else row))
             elems.append(tags.Tr([], res))
         tab = tags.Table([
-                attributes.InlineStyle(width="100%"),
+                attributes.Style(width="100%"),
                 attributes.Class("table_border") if border else None,
             ],
             elems,
@@ -310,7 +310,7 @@ class EmailBuilder(InDriver):
             attributes.Height(height),
             attributes.Width(width),
             {"name": "border", "value": 0},
-            attributes.InlineStyle(
+            attributes.Style(
                 border_radius="4px",
                 margin=self.__align(align),
                 display="block",
@@ -325,7 +325,7 @@ class EmailBuilder(InDriver):
     def title(self, title, heading=None):
         self.deprecatedPrint()
         return tags.H1([
-                attributes.InlineStyle(
+                attributes.Style(
                     color="#000000",
                     font_size="32px",
                     font_weight="800",
@@ -338,7 +338,7 @@ class EmailBuilder(InDriver):
             tags.Br(),
             (
                 tags.Span([
-                        attributes.InlineStyle(
+                        attributes.Style(
                             font_size="24px", font_weight="600", color="darkgray"
                         ),
                     ],
@@ -352,7 +352,7 @@ class EmailBuilder(InDriver):
     def heading(self, text):
         self.deprecatedPrint()
         return tags.H2([
-                attributes.InlineStyle(
+                attributes.Style(
                     color="#000000",
                     font_size="28px",
                     font_weight="600",
@@ -371,7 +371,7 @@ class EmailBuilder(InDriver):
     def text(self, text, font_size="18px"):
         self.deprecatedPrint()
         return tags.P([
-                attributes.InlineStyle(
+                attributes.Style(
                     font_size=font_size, padding_left="10px", padding_right="10px"
                 ),
             ],
@@ -386,7 +386,7 @@ class EmailBuilder(InDriver):
         self.deprecatedPrint()
         one = [
             [
-                attributes.InlineStyle(
+                attributes.Style(
                     font_size="16px",
                     font_weight="400",
                     line_height="24px",
@@ -506,16 +506,16 @@ class EmailBuilder(InDriver):
                 tags.Style([], base_style),
                 tags.Title([], title),
             ),
-            tags.Body([attributes.InlineStyle(margin="0 !important", padding="0 !important")],
+            tags.Body([attributes.Style(margin="0 !important", padding="0 !important")],
                 tags.Div([
-                        attributes.InlineStyle(
+                        attributes.Style(
                             display="none", max_height="0", overflow="hidden"
                         ),
                     ],
                     title,
                 ),
                 tags.Div([
-                        attributes.InlineStyle(
+                        attributes.Style(
                             display="none", max_height="0", overflow="hidden"
                         ),
                     ],
@@ -525,7 +525,7 @@ class EmailBuilder(InDriver):
                 tags.Div([
                         attributes.Lang("en"),
                         attributes.Class("basic_font"),
-                        attributes.InlineStyle(
+                        attributes.Style(
                             background_color="white",
                             color="#2b2b2b",
                             font_size="18px",

--- a/naas_drivers/input/emailbuilder.py
+++ b/naas_drivers/input/emailbuilder.py
@@ -164,22 +164,24 @@ class EmailBuilder(InDriver):
 
     def address(self, title, content):
         self.deprecatedPrint()
-        return tags.Address(
-            attributes.InlineStyle(
-                font_size="16px",
-                font_style="normal",
-                font_weight="400",
-                line_height="24px",
-            ),
-            tags.Strong(tags.Text(title)),
+        return tags.Address([
+                attributes.InlineStyle(
+                    font_size="16px",
+                    font_style="normal",
+                    font_weight="400",
+                    line_height="24px",
+                )
+            ],
+            tags.Strong([], tags.Text(title)),
             tags.Text(content),
         )
 
     def link(self, link, title="Open", color="#B200FD"):
         self.deprecatedPrint()
-        return tags.A(
-            attributes.Href(link),
-            attributes.InlineStyle(color=color, text_decoration="underline"),
+        return tags.A([
+                attributes.Href(link),
+                attributes.InlineStyle(color=color, text_decoration="underline"),
+            ],
             tags.Text(title),
         )
 
@@ -192,10 +194,9 @@ class EmailBuilder(InDriver):
         background_color="black",
     ):
         self.deprecatedPrint()
-        return tags.Center(
-            tags.Div(
-                attributes.InlineStyle(margin="48px 0"),
-                tags.A(
+        return tags.Center([]
+            tags.Div([attributes.InlineStyle(margin="48px 0")],
+                tags.A([
                     attributes.Class("button"),
                     attributes.Href(link),
                     attributes.InlineStyle(
@@ -214,20 +215,22 @@ class EmailBuilder(InDriver):
                         padding_left="10px",
                         padding_right="10px",
                         _webkit_text_size_adjust="none",
-                    ),
-                    tags.Text(text),
+                    )
+                ],
+                tags.Text(text),
                 ),
             )
         )
 
     def info(self, *elems):
         self.deprecatedPrint()
-        return tags.Div(
-            attributes.InlineStyle(
-                background_color="ghostwhite",
-                border_radius="4px",
-                padding="24px 48px",
-            ),
+        return tags.Div([
+                attributes.InlineStyle(
+                    background_color="ghostwhite",
+                    border_radius="4px",
+                    padding="24px 48px",
+                )
+            ],
             *elems,
         )
 
@@ -269,28 +272,28 @@ class EmailBuilder(InDriver):
                             if col != "row_link":
                                 link = row[row_link_index]
                                 res.append(
-                                    tags.Td(
-                                        tags.A(
-                                            attributes.Href(link),
+                                    tags.Td([],
+                                        tags.A([attributes.Href(link)],
                                             self.__convert(cell, col),
                                         )
                                     )
                                 )
                         else:
-                            res.append(tags.Td(self.__convert(cell, col)))
+                            res.append(tags.Td([], self.__convert(cell, col)))
                     else:
                         res.append(
-                            tags.Td(tags.Text(cell) if isinstance(cell, str) else cell)
+                            tags.Td([], tags.Text(cell) if isinstance(cell, str) else cell)
                         )
             else:
-                res.append(tags.Td(tags.Text(row) if isinstance(row, str) else row))
-            elems.append(tags.Tr(res))
-        tab = tags.Table(
-            attributes.InlineStyle(width="100%"),
-            attributes.Class("table_border") if border else None,
+                res.append(tags.Td([], tags.Text(row) if isinstance(row, str) else row))
+            elems.append(tags.Tr([], res))
+        tab = tags.Table([
+                attributes.InlineStyle(width="100%"),
+                attributes.Class("table_border") if border else None,
+            ],
             elems,
         )
-        return tags.P(tab)
+        return tags.P([], tab)
 
     def logo(self, src, link=None, name="Logo", align="center", size="80px"):
         self.deprecatedPrint()
@@ -302,7 +305,7 @@ class EmailBuilder(InDriver):
         self.deprecatedPrint()
         if src is None:
             return None
-        elems_img = [
+        attrs_img = [
             attributes.Src(f"{src}?naas_uid={str(uuid.uuid4())}"),
             attributes.Height(height),
             attributes.Width(width),
@@ -315,28 +318,30 @@ class EmailBuilder(InDriver):
             {"name": "alt", "value": name},
         ]
         if link:
-            return tags.A(attributes.Href(link), tags.Img(elems_img))
+            return tags.A([attributes.Href(link)], tags.Img([attrs_img]))
         else:
-            return tags.Img(elems_img)
+            return tags.Img([attrs_img])
 
     def title(self, title, heading=None):
         self.deprecatedPrint()
-        return tags.H1(
-            attributes.InlineStyle(
-                color="#000000",
-                font_size="32px",
-                font_weight="800",
-                line_height="32px",
-                margin="48px 0",
-                text_align="center",
-            ),
+        return tags.H1([
+                attributes.InlineStyle(
+                    color="#000000",
+                    font_size="32px",
+                    font_weight="800",
+                    line_height="32px",
+                    margin="48px 0",
+                    text_align="center",
+                ),
+            ],
             tags.Text(title),
             tags.Br(),
             (
-                tags.Span(
-                    attributes.InlineStyle(
-                        font_size="24px", font_weight="600", color="darkgray"
-                    ),
+                tags.Span([
+                        attributes.InlineStyle(
+                            font_size="24px", font_weight="600", color="darkgray"
+                        ),
+                    ],
                     tags.Text(heading),
                 )
                 if heading
@@ -346,15 +351,16 @@ class EmailBuilder(InDriver):
 
     def heading(self, text):
         self.deprecatedPrint()
-        return tags.H2(
-            attributes.InlineStyle(
-                color="#000000",
-                font_size="28px",
-                font_weight="600",
-                line_height="32px",
-                margin="48px 0 24px 0",
-                text_align="center",
-            ),
+        return tags.H2([
+                attributes.InlineStyle(
+                    color="#000000",
+                    font_size="28px",
+                    font_weight="600",
+                    line_height="32px",
+                    margin="48px 0 24px 0",
+                    text_align="center",
+                ),
+            ],
             tags.Text(text),
         )
 
@@ -364,30 +370,33 @@ class EmailBuilder(InDriver):
 
     def text(self, text, font_size="18px"):
         self.deprecatedPrint()
-        return tags.P(
+        return tags.P([
+                attributes.InlineStyle(
+                    font_size=font_size, padding_left="10px", padding_right="10px"
+                ),
+            ],
             tags.Text(text),
-            attributes.InlineStyle(
-                font_size=font_size, padding_left="10px", padding_right="10px"
-            ),
         )
 
     def header(self, *elems):
         self.deprecatedPrint()
-        return tags.Header(*elems)
+        return tags.Header([], *elems)
 
     def footer(self, text, first=None, *elems):
         self.deprecatedPrint()
         one = [
-            attributes.InlineStyle(
-                font_size="16px",
-                font_weight="400",
-                line_height="24px",
-                margin_top="48px",
-            ),
+            [
+                attributes.InlineStyle(
+                    font_size="16px",
+                    font_weight="400",
+                    line_height="24px",
+                    margin_top="48px",
+                ),
+            ],
             tags.Text(text),
             first,
         ]
-        return tags.Footer(tags.P(one), *elems)
+        return tags.Footer([], tags.P([], *one), *elems)
 
     def main(
         self,
@@ -397,7 +406,7 @@ class EmailBuilder(InDriver):
         items = []
         for key, value in kwargs.items():
             items.append(self.__convert(value, key))
-        return [tags.Main(items)]
+        return [tags.Main([], items)]
 
     def __display(self, content, mode):
         uid = uuid.uuid4().hex
@@ -476,58 +485,59 @@ class EmailBuilder(InDriver):
 
     def generate(self, title, logo=None, display="embed", footer=None, **kwargs):
         self.deprecatedPrint()
-        gen_html = tags.Html(
-            attributes.Lang("en"),
-            tags.Head(
-                tags.Meta(
+        gen_html = tags.Html([attributes.Lang("en")],
+            tags.Head([],
+                tags.Meta([
                     attributes.HttpEquiv("Content-Type"),
                     attributes.Content("text/html; charset=utf-8"),
-                ),
-                tags.Meta(
+                ]),
+                tags.Meta([
                     attributes.HttpEquiv("Content-Type"),
                     attributes.Content("width=device-width, initial-scale=1"),
-                ),
-                tags.Meta(
+                ]),
+                tags.Meta([
                     attributes.Name("viewport"),
                     attributes.Content("width=device-width, initial-scale=1"),
-                ),
-                tags.Meta(
+                ]),
+                tags.Meta([
                     attributes.HttpEquiv("X-UA-Compatible"),
                     attributes.Content("IE=edge"),
-                ),
-                tags.Style(tags.Text(base_style)),
-                tags.Title(tags.Text(title)),
+                ]),
+                tags.Style([], tags.Text(base_style)),
+                tags.Title([], tags.Text(title)),
             ),
-            tags.Body(
-                attributes.InlineStyle(margin="0 !important", padding="0 !important"),
-                tags.Div(
-                    attributes.InlineStyle(
-                        display="none", max_height="0", overflow="hidden"
-                    ),
+            tags.Body([attributes.InlineStyle(margin="0 !important", padding="0 !important")],
+                tags.Div([
+                        attributes.InlineStyle(
+                            display="none", max_height="0", overflow="hidden"
+                        ),
+                    ],
                     tags.Text(title),
                 ),
-                tags.Div(
-                    attributes.InlineStyle(
-                        display="none", max_height="0", overflow="hidden"
-                    ),
+                tags.Div([
+                        attributes.InlineStyle(
+                            display="none", max_height="0", overflow="hidden"
+                        ),
+                    ],
                     tags.Text("&nbsp;‌" * 240),
                 ),
                 tags.Text(table_ie9),
-                tags.Div(
+                tags.Div([
+                        attributes.Lang("en"),
+                        attributes.Class("basic_font"),
+                        attributes.InlineStyle(
+                            background_color="white",
+                            color="#2b2b2b",
+                            font_size="18px",
+                            font_weight="400",
+                            line_height="28px",
+                            margin="0 auto",
+                            max_width="720px",
+                            padding="40px 20px 40px 20px",
+                        ),
+                    ],
                     {"name": "role", "value": "article"},
                     {"name": "aria-label", "value": title},
-                    attributes.Lang("en"),
-                    attributes.Class("basic_font"),
-                    attributes.InlineStyle(
-                        background_color="white",
-                        color="#2b2b2b",
-                        font_size="18px",
-                        font_weight="400",
-                        line_height="28px",
-                        margin="0 auto",
-                        max_width="720px",
-                        padding="40px 20px 40px 20px",
-                    ),
                     self.header(logo, self.title(title)),
                     self.main(**kwargs),
                     footer,

--- a/naas_drivers/input/emailbuilder.py
+++ b/naas_drivers/input/emailbuilder.py
@@ -194,30 +194,32 @@ class EmailBuilder(InDriver):
         background_color="black",
     ):
         self.deprecatedPrint()
-        return tags.Center([]
-            tags.Div([attributes.Style(margin="48px 0")],
+        return tags.Center(
+            [],
+            tags.Div(
+                [attributes.Style(margin="48px 0")],
                 tags.A([
-                    attributes.Class("button"),
-                    attributes.Href(link),
-                    attributes.Style(
-                        background_color=background_color,
-                        color=color,
-                        border_radius="4px",
-                        display="inline-block",
-                        font_family="sans-serif",
-                        font_size="18px",
-                        font_weight="bold",
-                        line_height="60px",
-                        text_align="center",
-                        text_decoration="none",
-                        width=width,
-                        max_width="300px",
-                        padding_left="10px",
-                        padding_right="10px",
-                        _webkit_text_size_adjust="none",
-                    )
-                ],
-                text,
+                        attributes.Class("button"),
+                        attributes.Href(link),
+                        attributes.Style(
+                            background_color=background_color,
+                            color=color,
+                            border_radius="4px",
+                            display="inline-block",
+                            font_family="sans-serif",
+                            font_size="18px",
+                            font_weight="bold",
+                            line_height="60px",
+                            text_align="center",
+                            text_decoration="none",
+                            width=width,
+                            max_width="300px",
+                            padding_left="10px",
+                            padding_right="10px",
+                            _webkit_text_size_adjust="none",
+                        )
+                    ],
+                    text,
                 ),
             )
         )
@@ -272,8 +274,10 @@ class EmailBuilder(InDriver):
                             if col != "row_link":
                                 link = row[row_link_index]
                                 res.append(
-                                    tags.Td([],
-                                        tags.A([attributes.Href(link)],
+                                    tags.Td(
+                                        [],
+                                        tags.A(
+                                            [attributes.Href(link)],
                                             self.__convert(cell, col),
                                         )
                                     )
@@ -485,8 +489,10 @@ class EmailBuilder(InDriver):
 
     def generate(self, title, logo=None, display="embed", footer=None, **kwargs):
         self.deprecatedPrint()
-        gen_html = tags.Html([attributes.Lang("en")],
-            tags.Head([],
+        gen_html = tags.Html(
+            [attributes.Lang("en")],
+            tags.Head(
+                [],
                 tags.Meta([
                     attributes.HttpEquiv("Content-Type"),
                     attributes.Content("text/html; charset=utf-8"),
@@ -506,7 +512,8 @@ class EmailBuilder(InDriver):
                 tags.Style([], base_style),
                 tags.Title([], title),
             ),
-            tags.Body([attributes.Style(margin="0 !important", padding="0 !important")],
+            tags.Body(
+                [attributes.Style(margin="0 !important", padding="0 !important")],
                 tags.Div([
                         attributes.Style(
                             display="none", max_height="0", overflow="hidden"

--- a/naas_drivers/input/emailbuilder.py
+++ b/naas_drivers/input/emailbuilder.py
@@ -172,8 +172,8 @@ class EmailBuilder(InDriver):
                     line_height="24px",
                 )
             ],
-            tags.Strong([], tags.Text(title)),
-            tags.Text(content),
+            tags.Strong([], title),
+            content,
         )
 
     def link(self, link, title="Open", color="#B200FD"):
@@ -182,7 +182,7 @@ class EmailBuilder(InDriver):
                 attributes.Href(link),
                 attributes.InlineStyle(color=color, text_decoration="underline"),
             ],
-            tags.Text(title),
+            title,
         )
 
     def button(
@@ -217,7 +217,7 @@ class EmailBuilder(InDriver):
                         _webkit_text_size_adjust="none",
                     )
                 ],
-                tags.Text(text),
+                text,
                 ),
             )
         )
@@ -282,10 +282,10 @@ class EmailBuilder(InDriver):
                             res.append(tags.Td([], self.__convert(cell, col)))
                     else:
                         res.append(
-                            tags.Td([], tags.Text(cell) if isinstance(cell, str) else cell)
+                            tags.Td([], cell if isinstance(cell, str) else cell)
                         )
             else:
-                res.append(tags.Td([], tags.Text(row) if isinstance(row, str) else row))
+                res.append(tags.Td([], row if isinstance(row, str) else row))
             elems.append(tags.Tr([], res))
         tab = tags.Table([
                 attributes.InlineStyle(width="100%"),
@@ -334,7 +334,7 @@ class EmailBuilder(InDriver):
                     text_align="center",
                 ),
             ],
-            tags.Text(title),
+            title,
             tags.Br(),
             (
                 tags.Span([
@@ -342,7 +342,7 @@ class EmailBuilder(InDriver):
                             font_size="24px", font_weight="600", color="darkgray"
                         ),
                     ],
-                    tags.Text(heading),
+                    heading,
                 )
                 if heading
                 else None
@@ -361,7 +361,7 @@ class EmailBuilder(InDriver):
                     text_align="center",
                 ),
             ],
-            tags.Text(text),
+            text,
         )
 
     def subheading(self, text):
@@ -375,7 +375,7 @@ class EmailBuilder(InDriver):
                     font_size=font_size, padding_left="10px", padding_right="10px"
                 ),
             ],
-            tags.Text(text),
+            text,
         )
 
     def header(self, *elems):
@@ -393,7 +393,7 @@ class EmailBuilder(InDriver):
                     margin_top="48px",
                 ),
             ],
-            tags.Text(text),
+            text,
             first,
         ]
         return tags.Footer([], tags.P([], *one), *elems)
@@ -503,8 +503,8 @@ class EmailBuilder(InDriver):
                     attributes.HttpEquiv("X-UA-Compatible"),
                     attributes.Content("IE=edge"),
                 ]),
-                tags.Style([], tags.Text(base_style)),
-                tags.Title([], tags.Text(title)),
+                tags.Style([], base_style),
+                tags.Title([], title),
             ),
             tags.Body([attributes.InlineStyle(margin="0 !important", padding="0 !important")],
                 tags.Div([
@@ -512,16 +512,16 @@ class EmailBuilder(InDriver):
                             display="none", max_height="0", overflow="hidden"
                         ),
                     ],
-                    tags.Text(title),
+                    title,
                 ),
                 tags.Div([
                         attributes.InlineStyle(
                             display="none", max_height="0", overflow="hidden"
                         ),
                     ],
-                    tags.Text("&nbsp;‌" * 240),
+                    "&nbsp;‌" * 240,
                 ),
-                tags.Text(table_ie9),
+                table_ie9,
                 tags.Div([
                         attributes.Lang("en"),
                         attributes.Class("basic_font"),
@@ -542,7 +542,7 @@ class EmailBuilder(InDriver):
                     self.main(**kwargs),
                     footer,
                 ),
-                tags.Text(table_ie9_close),
+                table_ie9_close,
             ),
         )
         res = gen_html.render()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pyjwt>=1,<3",
         "tensorflow>=2,<3",
         "pysftp>=0,<1",
-        "htmlbuilder>=0,<1",
+        "htmlbuilder>=1,<2",
         "vaderSentiment>=3,<4",
         "chardet>=3,<5",
         "Cython>=0,<1",


### PR DESCRIPTION
Hello
I noticed you guys are using htmlBuilder. Although I'm glad it's useful ❤️ , your current version is pretty old, and most importantly, because of how your dependencies are set up, you could end up installing a more recent version (which contains non-backward compatible changes). 

So I took the liberty of spending a few minutes migrating the `emailbuilder.py` module to be compatible with htmlBuilder v1.0.0 (Hope that's ok). Sadly, I could not run tests on this code (unsure if you have those available), so be sure to test it and do some QA, but I hope these changes are a good place to start. 

## Note: 
Pay special attention to this code
 ```python
            attrs_img = [
            attributes.Src(f"{src}?naas_uid={str(uuid.uuid4())}"),
            attributes.Height(height),
            attributes.Width(width),
            {"name": "border", "value": 0},
            attributes.Style(
                border_radius="4px",
                margin=self.__align(align),
                display="block",
            ),
            {"name": "alt", "value": name},
        ]
        if link:
            return tags.A([attributes.Href(link)], tags.Img([attrs_img]))
        else:
            return tags.Img([attrs_img])
```

As I'm not sure how the lines 
 - `{"name": "border", "value": 0},`
 - `{"name": "alt", "value": name},`
are intended to work. 