### PR TITLE
Feat: Prediction Columns flexibility

### DIFF
--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -172,7 +172,7 @@ class Prediction:
             concat_label=None,
     ):
         # Fallback for columns
-        if column not in dataset.columns:
+        if column not in dataset.columns or column is None or column == "":
             column = "Close"
 
         # initializes the class variables

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -3,7 +3,6 @@ import numpy as np
 
 
 class Prediction:
-
     param_model_map = {"arima": "ARIMA", "linear": "LINEAR", "svr": "SVR"}
     # either all to predict using all the models else one of arima, svr or linear
     prediction_type = None
@@ -37,12 +36,6 @@ class Prediction:
     )
 
     def __init_class_vars(
-        self,
-        prediction_type: str,
-        dataset: pd.DataFrame,
-        label: str,
-        date_column: str,
-        data_points: int,
     ):
 
         # either all to predict using all the models else one of arima, svr or linear
@@ -94,8 +87,6 @@ class Prediction:
             model.fit(X, y)
             x_predict = (
                 df[self.label]
-                .to_numpy()
-                .reshape(-1, 1)[-self.data_points :]  # noqa: E203
             )
             predicted_values = model.predict(x_predict)
         else:
@@ -164,27 +155,16 @@ class Prediction:
         return predicted_cols, output_dfs
 
     def get(
-        self,
-        dataset: pd.DataFrame,
-        prediction_type: str = "COMPOUND",
-        label: str = "Close",
-        date_column: str = "Date",
-        data_points: int = 20,
-        concat_label=None,
     ):
         # initializes the class variables
         self.__init_class_vars(
             prediction_type=prediction_type,
             dataset=dataset,
-            label=label,
             date_column=date_column,
             data_points=data_points,
         )
 
         # modelling and making the predictions
-        output_dfs = None
-        predicted_cols = None
-        group = None
         if "Company" in dataset.columns:
             group = ["Date", "Company"]
             predicted_cols, output_dfs = self.__multi_company()
@@ -205,10 +185,8 @@ class Prediction:
         if concat_label is not None:
             if len(predicted_cols) > 1:
                 res[concat_label] = res["COMPOUND"].replace(np.nan, 0.000000) + res[
-                    label
                 ].replace(np.nan, 0.000000)
             else:
                 res[concat_label] = res[predicted_cols[0]].replace(
                     np.nan, 0.000000
-                ) + res[label].replace(np.nan, 0.000000)
         return res

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -94,6 +94,7 @@ class Prediction:
             x_predict = (
                 df[self.label]
                     .to_numpy()
+                    .reshape(-1, 1)[-self.data_points:]  # noqa: E203
             )
             predicted_values = model.predict(x_predict)
         else:
@@ -162,7 +163,18 @@ class Prediction:
         return predicted_cols, output_dfs
 
     def get(
+            self,
+            dataset: pd.DataFrame,
+            column: str,
+            prediction_type: str = "COMPOUND",
+            date_column: str = "Date",
+            data_points: int = 20,
+            concat_label=None,
     ):
+        # Fallback for columns
+        if column not in dataset.columns:
+            column = "Close"
+
         # initializes the class variables
         self.__init_class_vars(
             prediction_type=prediction_type,

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -179,6 +179,7 @@ class Prediction:
         self.__init_class_vars(
             prediction_type=prediction_type,
             dataset=dataset,
+            label=column,
             date_column=date_column,
             data_points=data_points,
         )

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -165,7 +165,7 @@ class Prediction:
     def get(
             self,
             dataset: pd.DataFrame,
-            column: str,
+            column: str = "Close",
             prediction_type: str = "COMPOUND",
             date_column: str = "Date",
             data_points: int = 20,

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -36,6 +36,7 @@ class Prediction:
     )
 
     def __init_class_vars(
+            self,
     ):
 
         # either all to predict using all the models else one of arima, svr or linear

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -185,6 +185,9 @@ class Prediction:
         )
 
         # modelling and making the predictions
+        # output_dfs = None
+        # predicted_cols = None
+        # group = None
         if "Company" in dataset.columns:
             group = ["Date", "Company"]
             predicted_cols, output_dfs = self.__multi_company()
@@ -205,8 +208,10 @@ class Prediction:
         if concat_label is not None:
             if len(predicted_cols) > 1:
                 res[concat_label] = res["COMPOUND"].replace(np.nan, 0.000000) + res[
+                    column
                 ].replace(np.nan, 0.000000)
             else:
                 res[concat_label] = res[predicted_cols[0]].replace(
                     np.nan, 0.000000
+                ) + res[column].replace(np.nan, 0.000000)
         return res

--- a/naas_drivers/input/prediction.py
+++ b/naas_drivers/input/prediction.py
@@ -37,6 +37,11 @@ class Prediction:
 
     def __init_class_vars(
             self,
+            prediction_type: str,
+            dataset: pd.DataFrame,
+            label: str,
+            date_column: str,
+            data_points: int,
     ):
 
         # either all to predict using all the models else one of arima, svr or linear
@@ -88,6 +93,7 @@ class Prediction:
             model.fit(X, y)
             x_predict = (
                 df[self.label]
+                    .to_numpy()
             )
             predicted_values = model.predict(x_predict)
         else:


### PR DESCRIPTION
# Prediction driver

### Issue
Currently, we can only predict on the "Close" column which can be inaccurate in some cases

### Currently
```python
import naas_drivers

dataset = naas_drivers.yahoo.stock("TSLA")
pr = naas_drivers.prediction.get(dataset=dataset, prediction_type="all") 
# Input colmun cannot be changed and is fixed at "Close"
```
### New Additions
```python
import naas_drivers

dataset = naas_drivers.yahoo.stock("TSLA")
pr = naas_drivers.prediction.get(dataset=dataset, column="Open", prediction_type="all")
# Input column is flexible and if not found it will default to "Close"
```