### PR TITLE
fix: put the query into args

### DIFF
--- a/naas_drivers/input/newsapi.py
+++ b/naas_drivers/input/newsapi.py
@@ -43,18 +43,21 @@ class Newsapi(InDriver):
     def get_sources(
         self, q, fields=["image", "title", "source", "link"], limit=20, **kargs
     ):
+        kargs['q'] = q
         self.check_connect()
         newsapi = NewsApiClient(api_key=self.__key)
         sources = newsapi.get_sources(**kargs)
         return self.__transformDate(sources.get("sources"), fields, limit)
 
     def get_top(self, q, fields=["image", "title", "source", "link"], limit=20, **kargs):
+        kargs['q'] = q
         self.check_connect()
         newsapi = NewsApiClient(api_key=self.__key)
         tops = newsapi.get_top_headlines(**kargs)
         return self.__transformDate(tops.get("articles"), fields, limit)
 
     def get(self, q, fields=["image", "title", "source", "link"], limit=20, **kargs):
+        kargs['q'] = q
         self.check_connect()
         newsapi = NewsApiClient(api_key=self.__key)
         all_news = newsapi.get_everything(**kargs)


### PR DESCRIPTION
Link to this issue : https://github.com/jupyter-naas/drivers/issues/138

In order to facilitate the use of the API on naas, a new parameter has been added in the gets functions. This allows you to add the query directly before calling fields (latest PR)

To fix the last refactor, we put the query in the arguments in order to pass it directly.