### PR TITLE
feat(Plan): Add naascredits.get_plan() to get current plan from the api

### DIFF
--- a/naas_drivers/tools/naas_credits.py
+++ b/naas_drivers/tools/naas_credits.py
@@ -24,6 +24,13 @@ class NaasCredits(InDriver, OutDriver):
         self.__headers = naas_auth.headers
         return self
 
+    def get_plan(self):
+        res = r.get(
+            f"{AUTH_API_PROTOCOL}://{CREDITS_API_FQDN}/plan", headers=self.headers
+        )
+        res.raise_for_status()
+        return res.json()
+
     def get_balance(self):
         res = r.get(
             f"{AUTH_API_PROTOCOL}://{CREDITS_API_FQDN}/balance", headers=self.headers


### PR DESCRIPTION
This pull request is adding the capability to get the actual user plan from naas credits api.