### PR TITLE
fix(notion): Make sure we do not send rich_text containing empty plain_text

### DIFF
--- a/naas_drivers/tools/notion.py
+++ b/naas_drivers/tools/notion.py
@@ -11,6 +11,7 @@ import logging
 from copy import deepcopy
 import pandas as pd
 import threading
+import pydash
 
 VERSION = "2021-08-16"
 
@@ -176,6 +177,7 @@ class Notion(InDriver, OutDriver):
                         "created_time",
                     ]
                     and getattr(prop, prop.type) is not None
+                    and not (prop.type == 'rich_text' and pydash.get(getattr(prop, prop.type), '[0].plain_text') == '')
                 ):
                     filtered_properties[p] = prop
             copied.properties = filtered_properties

--- a/naas_drivers/tools/notion.py
+++ b/naas_drivers/tools/notion.py
@@ -177,7 +177,10 @@ class Notion(InDriver, OutDriver):
                         "created_time",
                     ]
                     and getattr(prop, prop.type) is not None
-                    and not (prop.type == 'rich_text' and pydash.get(getattr(prop, prop.type), '[0].plain_text') == '')
+                    and not (
+                        prop.type == "rich_text"
+                        and pydash.get(getattr(prop, prop.type), "[0].plain_text") == ""
+                    )
                 ):
                     filtered_properties[p] = prop
             copied.properties = filtered_properties


### PR DESCRIPTION
This pull request is fixing a new notion behaviour where it is not accepting a property `rich_text` if its `text.plain_text` is equal to an empty string.